### PR TITLE
Correction check_process

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,10 +1,11 @@
-## Test complet
+;; Test complet
 	auto_remove=1
-	# Manifest
+	; Manifest
 		domain="domain.tld"	(DOMAIN)
 		path="/cesium"	(PATH)
-		is_public=1	(PUBLIC|public=Yes|private=No)
-	# Checks
+		is_public=1	(PUBLIC|public=1|private=0)
+	; Checks
+		pkg_linter=1
 		setup_sub_dir=1
 		setup_root=1
 		setup_nourl=0
@@ -17,6 +18,6 @@
 		wrong_path=1
 		incorrect_path=1
 		corrupt_source=0
-		fail_download_source=1
+		fail_download_source=0
 		port_already_use=0
-		final_path_already_use=1
+		final_path_already_use=0


### PR DESCRIPTION
Correction du fichier check_process pour l'intégration continue.
Le package ne peut pas être testé correctement sans ce fichier.